### PR TITLE
refs #23019 - don't pass class to class_name in assocs

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -3,7 +3,7 @@ class Container < ApplicationRecord
   include Taxonomix
 
   belongs_to :compute_resource
-  belongs_to :registry, :class_name => "DockerRegistry", :foreign_key => :registry_id
+  belongs_to :registry, :class_name => 'DockerRegistry', :foreign_key => :registry_id
   has_many :environment_variables, :dependent  => :destroy, :foreign_key => :reference_id,
                                    :inverse_of => :container,
                                    :class_name => 'EnvironmentVariable'

--- a/app/models/docker_container_wizard_state.rb
+++ b/app/models/docker_container_wizard_state.rb
@@ -1,11 +1,11 @@
 class DockerContainerWizardState < ApplicationRecord
-  has_one :preliminary, :class_name => DockerContainerWizardStates::Preliminary,
+  has_one :preliminary, :class_name => 'DockerContainerWizardStates::Preliminary',
                         :dependent => :destroy, :validate => true, :autosave => true
-  has_one :image, :class_name => DockerContainerWizardStates::Image,
+  has_one :image, :class_name => 'DockerContainerWizardStates::Image',
                   :dependent => :destroy, :validate => true, :autosave => true
-  has_one :configuration, :class_name => DockerContainerWizardStates::Configuration,
+  has_one :configuration, :class_name => 'DockerContainerWizardStates::Configuration',
                           :dependent => :destroy, :validate => true, :autosave => true
-  has_one :environment, :class_name => DockerContainerWizardStates::Environment,
+  has_one :environment, :class_name => 'DockerContainerWizardStates::Environment',
                         :dependent => :destroy, :validate => true, :autosave => true
 
   delegate :compute_resource_id,   :to => :preliminary

--- a/app/models/docker_container_wizard_states/configuration.rb
+++ b/app/models/docker_container_wizard_states/configuration.rb
@@ -1,7 +1,7 @@
 module DockerContainerWizardStates
   class Configuration < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
-    belongs_to :wizard_state, :class_name => DockerContainerWizardState,
+    belongs_to :wizard_state, :class_name => 'DockerContainerWizardState',
                               :foreign_key => :docker_container_wizard_state_id
   end
 end

--- a/app/models/docker_container_wizard_states/environment.rb
+++ b/app/models/docker_container_wizard_states/environment.rb
@@ -1,7 +1,7 @@
 module DockerContainerWizardStates
   class Environment < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
-    belongs_to :wizard_state, :class_name => DockerContainerWizardState
+    belongs_to :wizard_state, :class_name => 'DockerContainerWizardState'
 
     has_many :environment_variables, :dependent  => :destroy, :foreign_key => :reference_id,
                                      :inverse_of => :environment,

--- a/app/models/docker_container_wizard_states/image.rb
+++ b/app/models/docker_container_wizard_states/image.rb
@@ -1,7 +1,7 @@
 module DockerContainerWizardStates
   class Image < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
-    belongs_to :wizard_state, :class_name => DockerContainerWizardState,
+    belongs_to :wizard_state, :class_name => 'DockerContainerWizardState',
                               :foreign_key => :docker_container_wizard_state_id
     delegate :compute_resource_id, :to => :wizard_state
     delegate :compute_resource, :to => :wizard_state

--- a/app/models/docker_container_wizard_states/preliminary.rb
+++ b/app/models/docker_container_wizard_states/preliminary.rb
@@ -3,7 +3,7 @@ module DockerContainerWizardStates
     include Taxonomix
 
     self.table_name_prefix = 'docker_container_wizard_states_'
-    belongs_to :wizard_state, :class_name => DockerContainerWizardState,
+    belongs_to :wizard_state, :class_name => 'DockerContainerWizardState',
                               :foreign_key => :docker_container_wizard_state_id
 
     belongs_to :compute_resource, :required => true


### PR DESCRIPTION
Addresses this deprecation warning for Rails 5.2:

DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies.
