### PR TITLE
Fixes #25988 - fix registries autocompletion

### DIFF
--- a/app/controllers/registries_controller.rb
+++ b/app/controllers/registries_controller.rb
@@ -40,6 +40,12 @@ class RegistriesController < ::ApplicationController
     end
   end
 
+  protected
+
+  def model_of_controller
+    DockerRegistry
+  end
+
   def find_registry
     @registry = DockerRegistry.find(params[:id])
   rescue ActiveRecord::RecordNotFound

--- a/app/views/registries/welcome.html.erb
+++ b/app/views/registries/welcome.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:title, _("Registries")) %>
+<div class="blank-slate-pf">
+  <div class="blank-slate-pf-icon">
+    <%= icon_text("gears", "", :kind => "fa") %>
+  </div>
+  <h1><%= _('Registries') %></h1>
+  <p><%= _("No registries found in this context.") %>
+  <%= _("This page shows registries available to the instance.") %></p>
+  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("3.x/index.html", {:root_url => 'https://theforeman.org/plugins/foreman_docker/'})%></p>
+  <div class="blank-slate-pf-main-action">
+    <%= new_link(_("Create Registry"), {}, { :class => "btn-lg" }) %>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :registries, :except => [:show]
+  resources :registries, :except => [:show] do
+    collection do
+      get 'auto_complete_search'
+    end
+  end
 
   scope path: '/docker', as: :foreman_docker do
     namespace :api, :defaults => { :format => 'json' } do


### PR DESCRIPTION
The registry autocomplete didn't seem to every work and https://github.com/theforeman/foreman/pull/6460 just made it apparent: the registry page is broken without this patch.

I also needed to add the welcome page, otherwise the auto complete tab was broken for empty result.