### PR TITLE
Fixes #19591 - provide clean up task

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,36 @@
+namespace :foreman_docker do
+  desc 'Clean default data created by this plugin, this will permanently delete the data!'
+  task :cleanup => :environment do
+    puts 'Cleaning data...'
+
+    User.as_anonymous_admin do
+      puts '... deleting records from taxable_taxonomies'
+      TaxableTaxonomy.where(:taxable_type => [ 'Container', 'DockerRegistry', 'Preliminary', 'ForemanDocker::Docker' ]).delete_all
+      puts '... deleting filters'
+      Filter.joins(:permissions).where('permissions.resource_type' => Foreman::Plugin.find(:foreman_docker).registered_permissions.map { |p, attrs| attrs[:resource_type] }.uniq!).destroy_all
+      puts '... deleting permissions'
+      Permission.where(:name => Foreman::Plugin.find(:foreman_docker).registered_permissions.map(&:first)).destroy_all
+      puts '... deleting docker compute resources'
+      ForemanDocker::Docker.destroy_all
+      puts 'data from all tables deleted'
+    end
+
+    tables = [
+      :containers,
+      :docker_registries,
+      :docker_container_wizard_states,
+      :docker_container_wizard_states_preliminaries,
+      :docker_container_wizard_states_images,
+      :docker_container_wizard_states_configurations,
+      :docker_container_wizard_states_environments,
+      :docker_parameters
+    ]
+    tables.each do |table|
+      puts "... dropping table #{table}"
+      ActiveRecord::Migration.drop_table table
+    end
+
+    puts 'Clean up finished, you can now remove the plugin from your system'
+  end
+end
+


### PR DESCRIPTION
@bastilian this is based on https://github.com/bastilian/foreman-docker/commit/913d4e9dcce9ed9a493ed08972254504ad5f848a, two tables didn't exist so I removed them. Please take a look and merge if you can.

We should also have some tooling in foreman-maintain that would uninstall the package, regenerate apipie cache, restart httpd. Or it could be installer upgrade task.
